### PR TITLE
Include composer in PHP Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM php:8.2-fpm-alpine
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 RUN apk add --no-cache bash git curl icu-dev zlib-dev libpng-dev oniguruma-dev \
   && docker-php-ext-install intl pdo_mysql mbstring exif pcntl bcmath gd


### PR DESCRIPTION
## Summary
- copy the composer binary from composer:2 into the PHP 8.2 FPM image so composer install can run during build

## Testing
- `docker build -t cctv-miot-app -f Dockerfile .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused; Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3a2301548328be88c3988c057b11