### PR TITLE
Specify app service Dockerfile in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,9 @@ version: "3.8"
 
 services:
   app:
-    build: .
+    build:
+      context: .
+      dockerfile: app/Dockerfile
     container_name: laravel-app
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary
- configure app service build to use app/Dockerfile with explicit context

## Testing
- `docker compose build app` *(fails: docker: 'compose' is not a docker command)*
- `docker-compose build app` *(fails: Connection aborted., ConnectionRefusedError(111, 'Connection refused'))*

------
https://chatgpt.com/codex/tasks/task_e_68ac3a1b9dfc8328a2c3a9e368d608d8